### PR TITLE
Add secure_filename util

### DIFF
--- a/cli/downloader.py
+++ b/cli/downloader.py
@@ -7,6 +7,7 @@ from termcolor import colored
 from resources.twitch import TwitchHelix
 from cli.constants import CONFIGURATION_FILE
 from tqdm import tqdm
+from werkzeug.utils import secure_filename
 
 
 class Downloader(object):
@@ -31,6 +32,8 @@ class Downloader(object):
     def _download_clip(self, source, filename):
         if " " in filename:
             filename = filename.replace(" ", "-")
+        filename = secure_filename(filename)
+
         downloaded_video = requests.get(source, stream=True)
         total_size = int(downloaded_video.headers.get("content-length", 0))
         block_size = 1024


### PR DESCRIPTION
Partially handles #12 for clips not downloading on Windows due to illegal characters.